### PR TITLE
ZGW-3429: Fixup! github: Release package, only on tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build Docker image from sources
         run: docker build --tag "zipgateway:latest" .
       - name: Release packages
-        if: ${{ github.event_name == 'push' }} && contains( ${{ github.ref }}, 'refs/tags/')
+        if: ${{ github.event_name == 'push' && contains( github.ref, 'refs/tags/') }}
         env:
           GH_TOKEN: ${{ secrets.ZIPGATEWAY_GH_TOKEN }}
         run: >


### PR DESCRIPTION
The condition should be evaluated in single context {{ .. }}

The observed issue was:

    a release with the same tag name already exists: main
    Error: Process completed with exit code 1.

Origin: https://github.com/SiliconLabs/zipgateway/pull/19
Relate-to: https://github.com/SiliconLabs/zipgateway/pull/17
Relate-to: https://github.com/SiliconLabs/zipgateway/actions/runs/10287581402/job/28470948249