### PR TITLE
Potential fix for code scanning alert no. 8: Potentially unsafe call to strncat

### DIFF
--- a/libzwaveip/examples/reference_apps/util.c
+++ b/libzwaveip/examples/reference_apps/util.c
@@ -27,7 +27,7 @@ const char* find_xml_file(char *argv0) {
   const char xml_filename[] = "/ZWave_custom_cmd_classes.xml";
   strncpy(xmlpath, dirname(argv0), PATH_MAX);
   xmlpath[PATH_MAX - 1] = 0;
-  strncat(xmlpath, xml_filename, PATH_MAX - strlen(xmlpath));
+  strncat(xmlpath, xml_filename, PATH_MAX - strlen(xmlpath) - 1);
   xmlpath[PATH_MAX - 1] = 0;
   return xmlpath;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/rzr/zipgateway/security/code-scanning/8](https://github.com/rzr/zipgateway/security/code-scanning/8)

To fix the issue, we need to ensure that the `strncat` call reserves space for the null terminator. This can be achieved by modifying the third argument to `PATH_MAX - strlen(xmlpath) - 1`. This adjustment ensures that the concatenated string, including the null terminator, fits within the bounds of the `xmlpath` buffer. Additionally, the explicit null-termination lines (`xmlpath[PATH_MAX - 1] = 0`) can remain as a safeguard.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
